### PR TITLE
further work on getting target to start

### DIFF
--- a/inc/systick_handler.h
+++ b/inc/systick_handler.h
@@ -1,4 +1,4 @@
-// OpenLager main
+// OpenLager systick handler
 //
 // Copyright (c) 2016, dRonin
 // All rights reserved.
@@ -24,16 +24,13 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
-#include <stm32f4xx_rcc.h>
-#include <systick_handler.h>
+#ifndef _SYSTICK_HANDLER_H
+#define _SYSTICK_HANDLER_H
 
-const void *_systick_vector __attribute((section(".systick_vector"))) = systick_handler;
+#include <stdint.h>
 
-const void *_interrupt_vectors[FPU_IRQn] __attribute((section(".interrupt_vectors"))) = {
-};
+void systick_handler() __attribute__((interrupt));
 
-int main() {
-	while (1);
+extern volatile uint32_t systick_cnt;
 
-	return 0;
-}
+#endif // _SYSTICK_HANDLER_H

--- a/shared/startup.c
+++ b/shared/startup.c
@@ -62,6 +62,7 @@ void _start(void)
 	__builtin_unreachable();
 }
 
+/* This ends one early, so other code can provide systick handler */
 const void *_vectors[] __attribute((section(".vectors"))) = {
 	&_stack_top,
 	_start,
@@ -78,5 +79,4 @@ const void *_vectors[] __attribute((section(".vectors"))) = {
 	0,	/* Reserved for debug */
 	0,	/* Reserved */
 	0,	/* PendSV */
-	0,	/* SysTick */
 };

--- a/shared/stm32f411.ld
+++ b/shared/stm32f411.ld
@@ -7,6 +7,8 @@ SECTIONS
 	{
 		. = ALIGN(4);
 		KEEP(*(.vectors))
+		KEEP(*(.systick_vector))
+		KEEP(*(.interrupt_vectors))
 		. = ALIGN(4);
 	} >FLASH
 
@@ -16,14 +18,14 @@ SECTIONS
 		*(.text) *(.text.*)
 		*(.glue_7t) *(.glue_7)
 		. = ALIGN(4);
-	}
+	} >FLASH
 
 	.rodata :
 	{
 		. = ALIGN(4);
 		*(.rodata) *(.rodata*)
 		. = ALIGN(4);
-	}
+	} >FLASH
 
 	_sidata = LOADADDR(.data);
 
@@ -34,7 +36,7 @@ SECTIONS
 		*(.data) *(.data*)
 		. = ALIGN(4);
 		_edata = .;
-	}
+	} >RAM AT> FLASH
 
 	.bss :
 	{

--- a/shared/systick_handler.c
+++ b/shared/systick_handler.c
@@ -1,4 +1,4 @@
-// OpenLager main
+// OpenLager systick handler
 //
 // Copyright (c) 2016, dRonin
 // All rights reserved.
@@ -24,16 +24,11 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
-#include <stm32f4xx_rcc.h>
 #include <systick_handler.h>
 
-const void *_systick_vector __attribute((section(".systick_vector"))) = systick_handler;
-
-const void *_interrupt_vectors[FPU_IRQn] __attribute((section(".interrupt_vectors"))) = {
-};
-
-int main() {
-	while (1);
-
-	return 0;
+void systick_handler() {
+	systick_cnt++;
 }
+
+volatile uint32_t systick_cnt;
+


### PR DESCRIPTION
- There's a systick handler and provisions for interrupt vectors.
- The linker script is altered to treat data right.
- We initialize the PLL and wait for clocks to be operational.
