### PR TITLE
Performance improvements

### DIFF
--- a/inc/sdio.h
+++ b/inc/sdio.h
@@ -31,6 +31,6 @@
 
 int sd_init(bool fourbit);
 int sd_read(uint8_t *data, uint32_t sect_num);
-int sd_write(const uint8_t *data, uint32_t sect_num);
+int sd_write(const uint8_t *data, uint32_t sect_num, uint16_t num_to_write);
 
 #endif

--- a/inc/usart.h
+++ b/inc/usart.h
@@ -33,6 +33,7 @@ void usart_init(uint32_t baud, void *rx_buf, unsigned int rx_buf_len);
 const char *usart_receive_chunk(unsigned int timeout,
 		unsigned int preferred_align,
 		unsigned int min_preferred_chunk,
+		unsigned int max_preferred_chunk,
 		unsigned int *bytes_returned);
 
 void usart_int_handler() __attribute__((interrupt));

--- a/shared/usart.c
+++ b/shared/usart.c
@@ -110,6 +110,7 @@ void usart_int_handler()
 const char *usart_receive_chunk(unsigned int timeout,
 		unsigned int preferred_align,
 		unsigned int min_preferred_chunk,
+		unsigned int max_preferred_chunk,
 		unsigned int *bytes_returned)
 {
 	unsigned int expiration = systick_cnt + timeout;
@@ -135,6 +136,10 @@ const char *usart_receive_chunk(unsigned int timeout,
 
 		if (bytes >= min_preferred_chunk) break;
 	} while (systick_cnt < expiration);
+
+	if (bytes > max_preferred_chunk) {
+		bytes = max_preferred_chunk;
+	}
 
 	if ((bytes + unalign) >= preferred_align) {
 		// Fixup for align

--- a/src/openlager.c
+++ b/src/openlager.c
@@ -301,7 +301,10 @@ static void do_usart_logging(void) {
 
 		// 50 ticks == 200ms, prefer 512 byte sector alignment,
 		// and >= 2560 byte chunks are best
-		pos = usart_receive_chunk(50, 512, 5*512, &amt);
+		// Never get more than about 2/5 of the buffer (40 * 1024)--
+		// because we want to finish the IO and free it up
+		pos = usart_receive_chunk(50, 512, 5*512,
+				40*1024, &amt);
 
 		// Could consider if pos is short, waiting a little longer
 		// (400-600ms?) next time...


### PR DESCRIPTION
Do multiple block writes, manage buffering a bit better, don't send redundant SD commands.

Fixes #39 
Fixes #37 

With this, was able to transfer 6MB file at 2000000 baud async (200,000 bytes per second) pegged.  No problem.
